### PR TITLE
Fix embedded Dockerfile location in create.yml

### DIFF
--- a/molecule_podman/playbooks/create.yml
+++ b/molecule_podman/playbooks/create.yml
@@ -26,15 +26,12 @@
       register: dockerfile_stats
 
     - name: Create Dockerfiles from image names
-      vars:
-        # TODO(ssbarnea): expose module dir so it can also be used by plugins
-        molecule_module_directory: "{{ playbook_dir + '/../../../..' }}"
       template:
         src: >-
           {%- if dockerfile_stats.results[i].stat.exists -%}
           {{ molecule_scenario_directory + '/' + (item.dockerfile | default( 'Dockerfile.j2')) }}
           {%- else -%}
-          {{ molecule_module_directory + '/data/Dockerfile.j2' }}
+          {{ playbook_dir + '/Dockerfile.j2' }}
           {%- endif -%}
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
         mode: "0600"


### PR DESCRIPTION
This is a similar fix to [1], where the path to the embedded Dockerfile
is wrong.

[1] - https://github.com/ansible-community/molecule-docker/pull/10