### PR TITLE
Avoid using pip 2020-resolver

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,12 @@ setenv =
     PYTHONUNBUFFERED=1
     # new resolve a must or test extras will not install right
     PIP_USE_FEATURE=2020-resolver
+    # endless loop bug on devel
+    devel: PIP_USE_FEATURE=
     MOLECULE_NO_LOG=0
 deps =
+    # https://github.com/willmcgugan/rich/issues/446
+    py36-devel: dataclasses==0.7
     devel: ansible>=2.10.0a2,<2.11
     py{36,37,38,39}: molecule[ansible,test]
     py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]


### PR DESCRIPTION
It seams that our tox -e py36-devel is also affected by the endless loop install bug from the new pip resolver, we are forced to disable it, at least for this job.

This change also includes another temporary workaround for rich, which fails to install due to pip conflicts when switching to the old resolver.

Example: https://github.com/ansible-community/molecule-podman/pull/23/checks?check_run_id=1458663833
Related: https://github.com/pypa/pip/issues/6536
Related: https://github.com/willmcgugan/rich/issues/446