### PR TITLE
Adopt use of pip 20.3 for testing

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -65,7 +65,7 @@ jobs:
           # sudo systemctl enable containerd
           podman version
           podman info
-          python -m pip install -U pip
+          python -m pip install -U "pip>=20.3b1"
           pip install tox
       - name: Run tox -e ${{ matrix.tox_env }}
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,8 +79,6 @@ docs =
     simplejson
     Sphinx
     sphinx_ansible_theme >= 0.2.2
-lint =
-    pre-commit >= 1.21.0
 
 [options.entry_points]
 molecule.driver =

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,9 @@ envlist =
     py{36,37,38,39}
     py{36,37,38,39}-{devel}
 
+requires =
+    virtualenv >= 20.2.1
+    pip >= 20.3b1
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
 isolated_build = True
@@ -33,20 +36,12 @@ setenv =
     PYTHONUNBUFFERED=1
     # new resolve a must or test extras will not install right
     PIP_USE_FEATURE=2020-resolver
-    # endless loop bug on devel
-    devel: PIP_USE_FEATURE=
     MOLECULE_NO_LOG=0
 deps =
-    # https://github.com/willmcgugan/rich/issues/446
-    py36-devel: dataclasses==0.7
-    devel: ansible>=2.10.0a2,<2.11
-    py{36,37,38,39}: molecule[ansible,test]
-    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
+    py{36,37,38,39}-{!devel}: molecule[ansible,test]>=3.2.0
+    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[ansible,test]
     dockerfile: ansible>=2.9.12
     selinux
-extras =
-    lint
-    test
 commands =
     ansibledevel: ansible-galaxy install git+https://github.com/ansible-collections/community.general.git
     # failsafe as pip may install incompatible dependencies
@@ -66,7 +61,6 @@ commands =
     # to run a single linter you can do "pre-commit run flake8"
     python -m pre_commit run {posargs:--all}
 deps = pre-commit>=1.18.1
-extras =
 skip_install = true
 usedevelop = false
 


### PR DESCRIPTION
Apparently the beta version of pip 20.3 seams to have resolved the endless loop bug caused by the new resolver.