### PR TITLE
Keep the same level of privileges when running with rootless: False

### DIFF
--- a/lib/molecule_podman/playbooks/create.yml
+++ b/lib/molecule_podman/playbooks/create.yml
@@ -50,6 +50,7 @@
       register: podman_images
 
     - name: Build an Ansible compatible image
+      become: "{{ not (item.item.rootless|default(true)) }}"
       command: >
         podman build
         -f {{ item.dest }}
@@ -119,4 +120,5 @@
       register: podman_jobs
       until: podman_jobs.finished
       retries: 300
+      become: "{{ not (item.item.rootless|default(true)) }}"
       with_items: "{{ server.results }}"

--- a/lib/molecule_podman/playbooks/destroy.yml
+++ b/lib/molecule_podman/playbooks/destroy.yml
@@ -4,9 +4,9 @@
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
-  become: "{{ not (item.rootless|default(true)) }}"
   tasks:
     - name: Destroy molecule instance(s)
+      become: "{{ not (item.rootless|default(true)) }}"
       shell: podman container exists {{ item.name }} && podman rm -f {{ item.name }} || true
       register: server
       with_items: "{{ molecule_yml.platforms }}"
@@ -14,6 +14,7 @@
       poll: 0
 
     - name: Wait for instance(s) deletion to complete
+      become: "{{ not (item.item.rootless|default(true)) }}"
       async_status:
         jid: "{{ item.ansible_job_id }}"
       register: docker_jobs


### PR DESCRIPTION
This fixes multiple bugs:

- Create/destroy, wait on the previous task as root too. Otherwise the
  task fails, as it doesn't have access to the job

- Build the image with the same user

## Notes

- I am not sure how to test that, and ensure it doesn't break again. Any advice would be much appreciated
- Using `rootless: False` would still fail with a similar error as #15 