### PR TITLE
Configure podman networks

### DIFF
--- a/lib/molecule_podman/playbooks/create.yml
+++ b/lib/molecule_podman/playbooks/create.yml
@@ -115,7 +115,7 @@
         {% if item.tmpfs is defined %}{% for i in item.tmpfs %}--tmpfs={{ i }} {% endfor %}{% endif %}
         {% if item.capabilities is defined %}{% for i in item.capabilities %}--cap-add={{ i }} {% endfor %}{% endif %}
         {% if item.exposed_ports is defined %}--expose="{{ item.exposed_ports|join(',') }}"{% endif %}
-        {% if item.published_ports is defined %}--publish="{{ item.published_ports|join(',') }}"{% endif %}
+        {% if item.published_ports is defined %}{% for i in item.published_ports %}--publish={{ i }}{% endfor %}{% endif %}
         {% if item.ulimits is defined %}{% for i in item.ulimits %}--ulimit={{ i }} {% endfor %}{% endif %}
         {% if item.dns_servers is defined %}--dns="{{ item.dns_servers|join(',') }}"{% endif %}
         {% if item.env is defined %}{% for i,k in item.env.items() %}--env={{ i }}={{ k }} {% endfor %}{% endif %}

--- a/lib/molecule_podman/playbooks/create.yml
+++ b/lib/molecule_podman/playbooks/create.yml
@@ -122,7 +122,7 @@
         {% if item.restart_policy is defined %}--restart={{ item.restart_policy }}{% if item.restart_retries is defined %}:{{ item.restart_retries }}{% endif %}{% endif %}
         {% if item.tty is defined %}--tty={{ item.tty }}{% endif %}
         {% if item.network is defined %}--network={{ item.network }}{% endif %}
-        {% if item.etc_hosts is defined %}{% for i,k in item.etc_hosts.items() %}--add-host {{ i }}:{{ k }} {% endfor %}{% endif %}
+        {% if item.etc_hosts is defined %}{% for i,k in item.etc_hosts.items() %}{% if i != item.name %}--add-host {{ i }}:{{ k }} {% endif %}{% endfor %}{% endif %}
         {% if item.hostname is defined %}--hostname={{ item.hostname }}{% elif item.name is defined %}--hostname={{ item.name }}{% endif %}
         {% if item.cgroup_manager is defined %}--cgroup-manager={{ item.cgroup_manager }}{% endif %}
         {% if item.storage_opt is defined %}--storage-opt={{ item.storage_opt }}{% endif %}

--- a/lib/molecule_podman/playbooks/create.yml
+++ b/lib/molecule_podman/playbooks/create.yml
@@ -110,6 +110,7 @@
         --name "{{ item.name }}"
         {% if item.pid_mode is defined %}--pid={{ item.pid_mode }}{% endif %}
         {% if item.privileged is defined %}--privileged={{ item.privileged }}{% endif %}
+        {% if item.detach is defined %}--detach{% endif %}
         {% if item.security_opts is defined %}{% for i in item.security_opts %}--security-opt {{ i }} {% endfor %}{% endif %}
         {% if item.volumes is defined %}{% for i in item.volumes %}--volume {{ i }} {% endfor %}{% endif %}
         {% if item.tmpfs is defined %}{% for i in item.tmpfs %}--tmpfs={{ i }} {% endfor %}{% endif %}

--- a/lib/molecule_podman/playbooks/create.yml
+++ b/lib/molecule_podman/playbooks/create.yml
@@ -80,6 +80,28 @@
       shell: >
         podman container exists {{ item.name }} && podman rm {{ item.name }} -f || true
       with_items: "{{ molecule_yml.platforms }}"
+    - name: Discover local podman networks
+      containers.podman.podman_network_info:
+        name: "{{ item.network }}"
+      loop: "{{ molecule_yml.platforms | flatten(levels=1) }}"
+      loop_control:
+        extended: true
+        label: "{{ item.name }}: {{ item.network | default('None specified') }}"
+      register: podman_network
+      when:
+        - item.network is defined
+        - ansible_loop.first
+      failed_when: false
+
+    - name: Create podman network dedicated to this scenario
+      containers.podman.podman_network:
+        name: "{{ podman_network.results[0].ansible_loop.allitems[0].network }}"
+        subnet:
+          "{{ podman_network.results[0].ansible_loop.allitems[0].subnet }}"
+      when:
+        - podman_network.results[0].msg is defined
+        - "'no such network' in podman_network.results[0].msg"
+        - podman_network.results[0].networks is undefined
 
     - name: Create molecule instance(s)
       command: >

--- a/lib/molecule_podman/playbooks/create.yml
+++ b/lib/molecule_podman/playbooks/create.yml
@@ -168,4 +168,4 @@
       retries: 300
       with_items: "{{ server.results }}"
       loop_control:
-        label: "{{ item.item.name | default('Unamed')}}"
+        label: "{{ item.item.name | default('Unnamed')}}"

--- a/lib/molecule_podman/playbooks/create.yml
+++ b/lib/molecule_podman/playbooks/create.yml
@@ -123,6 +123,7 @@
         {% if item.restart_policy is defined %}--restart={{ item.restart_policy }}{% if item.restart_retries is defined %}:{{ item.restart_retries }}{% endif %}{% endif %}
         {% if item.tty is defined %}--tty={{ item.tty }}{% endif %}
         {% if item.network is defined %}--network={{ item.network }}{% endif %}
+        {% if item.ip is defined %}--ip={{ item.ip }}{% endif %}
         {% if item.etc_hosts is defined %}{% for i,k in item.etc_hosts.items() %}{% if i != item.name %}--add-host {{ i }}:{{ k }} {% endif %}{% endfor %}{% endif %}
         {% if item.hostname is defined %}--hostname={{ item.hostname }}{% elif item.name is defined %}--hostname={{ item.name }}{% endif %}
         {% if item.cgroup_manager is defined %}--cgroup-manager={{ item.cgroup_manager }}{% endif %}


### PR DESCRIPTION
This pull request adds Podman network options that allow usage of static IP in containers. And also add Detach mode support.

With the following molecule.yml you can write scenarios that tests communication between containers without relying on complicated DNS setup:

```yaml
  platforms:
  
    - name: node1
      registry: &redhat {url: registry.access.redhat.com}
      image: &image ubi8/ubi-init
      tmpfs: &tmpfs ['/run', '/tmp']
      volumes: &volumes ['/sys/fs/cgroup:/sys/fs/cgroup:ro']
      capabilities: &capabilities ['SYS_ADMIN', 'NET_ADMIN']
      command: &command "/usr/sbin/init"
      security_opts: &security_opts ['label=disable']
      network: &network setup_dedicated
      subnet: &subnet '10.90.0.0/16'
      etc_hosts: &etc_hosts
        "node1": "10.90.0.101"
        "node2": "10.90.0.102"
      ip: 10.90.0.101
  
    - name: node2
      registry: *redhat
      image: *image
      tmpfs: *tmpfs
      volumes: *volumes
      capabilities: *capabilities
      command: *command
      security_opts: *security_opts
      network: *network
      subnet: *subnet
      etc_hosts: *etc_hosts
      ip: 10.90.0.102
```
    

It is impossible to change the /etc/hosts file on a running container. This is why I edited the create.yml Playbook to add this feature.