### PR TITLE
Require containers.podman collection 1.6.1 or newer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
         entry: mypy lib/
         pass_filenames: false
         additional_dependencies:
+          - ansible-lint>=5.1.0a0
           - molecule
           - packaging
   - repo: https://github.com/pre-commit/mirrors-pylint
@@ -57,5 +58,6 @@ repos:
     hooks:
       - id: pylint
         additional_dependencies:
-          - ansible-base
+          - ansible-core>=2.11.1
+          - ansible-lint>=5.1.0a0
           - molecule

--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,12 @@ Molecule Podman Plugin
    :target: LICENSE
    :alt: Repository License
 
-Molecule podman Plugin is designed to allow use Podman containers for
+Molecule Podman Plugin is designed to allow use Podman containers for
 provisioning test resources.
+
+This plugin requires `containers.podman` collection to be present:
+
+    ansible-galaxy collection install containers.podman
 
 Please note that this driver is currently in its early stage of development.
 

--- a/lib/molecule_podman/driver.py
+++ b/lib/molecule_podman/driver.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import os
 
+from ansiblelint.prerun import require_collection
 from molecule import logger
 from molecule.api import Driver
 from molecule.util import lru_cache
@@ -189,3 +190,4 @@ class Podman(Driver):
     def sanity_checks(self):
         """Implement Podman driver sanity checks."""
         log.info("Sanity checks: '{}'".format(self._name))
+        require_collection("containers.podman", "1.6.1")

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,8 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
+    # we need require_collection from ansiblelint.prerun
+    ansible-lint >= 5.1.0a0
     molecule >= 3.2.0
     # selinux python module is needed as least by ansible-podman modules
     # and allows us of isolated (default) virtualenvs. It does not avoid need

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,9 @@ deps =
     dockerfile: ansible>=2.9.12
     selinux
 commands =
-    ansibledevel: ansible-galaxy install git+https://github.com/ansible-collections/community.general.git
+    ansibledevel: ansible-galaxy collection install git+https://github.com/containers/ansible-podman-collections
+    # this should mention oldest version we find acceptable for runtime
+    ansible-galaxy collection install 'containers.podman:==1.6.1'
     # failsafe as pip may install incompatible dependencies
     pip check
     # failsafe for preventing changes that may break pytest collection


### PR DESCRIPTION
Adds check for presence of containers.podman collection and requires the latest known version to present. This means that this driver will no longer support podman modules shipped with Ansible 2.9 thus marking that change as major.

Still, installing the collection on 2.9 will make it work but that must be run by the user.

Needed-By: #38