### PR TITLE
Expose required collection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,6 @@ repos:
         entry: mypy lib/
         pass_filenames: false
         additional_dependencies:
-          - ansible-lint>=5.1.0a0
           - molecule
           - packaging
   - repo: https://github.com/pre-commit/mirrors-pylint
@@ -59,7 +58,6 @@ repos:
       - id: pylint
         additional_dependencies:
           - ansible-core>=2.11.1
-          - ansible-lint>=5.1.0a0
           - molecule
   - repo: https://github.com/ansible/ansible-lint.git
     rev: v5.1.0a0

--- a/lib/molecule_podman/driver.py
+++ b/lib/molecule_podman/driver.py
@@ -22,8 +22,8 @@
 from __future__ import absolute_import
 
 import os
+from typing import Dict
 
-from ansiblelint.prerun import require_collection
 from molecule import logger
 from molecule.api import Driver
 from molecule.util import lru_cache
@@ -190,4 +190,8 @@ class Podman(Driver):
     def sanity_checks(self):
         """Implement Podman driver sanity checks."""
         log.info("Sanity checks: '{}'".format(self._name))
-        require_collection("containers.podman", "1.6.1")
+
+    @property
+    def required_collections(self) -> Dict[str, str]:
+        """Return collections dict containing names and versions required."""
+        return {"containers.podman": "1.6.1"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,8 +66,6 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    # we need require_collection from ansiblelint.prerun
-    ansible-lint >= 5.1.0a0
     molecule >= 3.2.0
     # selinux python module is needed as least by ansible-podman modules
     # and allows us of isolated (default) virtualenvs. It does not avoid need


### PR DESCRIPTION
Use new molecule API to expose required collection and removes
dependency on ansiblelint.prerun module.

Depends-On: https://github.com/ansible-community/molecule/pull/3192