### PR TITLE
Remove use of pytest-helpers-namespace

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,1 @@
 """Pytest Config."""
-
-pytest_plugins = ["helpers_namespace"]

--- a/lib/molecule_podman/test/test_func.py
+++ b/lib/molecule_podman/test/test_func.py
@@ -3,9 +3,8 @@ import os
 import subprocess
 
 import molecule_podman
-import pytest
 from molecule import logger
-from molecule.test.conftest import change_dir_to
+from molecule.test.conftest import change_dir_to, molecule_directory
 from molecule.util import run_command
 
 LOG = logger.get_logger(__name__)
@@ -28,8 +27,7 @@ def test_command_init_scenario(temp_dir, DRIVER):
     assert result.returncode == 0
 
     with change_dir_to(role_directory):
-        molecule_directory = pytest.helpers.molecule_directory()
-        scenario_directory = os.path.join(molecule_directory, "test-scenario")
+        scenario_directory = os.path.join(molecule_directory(), "test-scenario")
         cmd = [
             "molecule",
             "init",


### PR DESCRIPTION
Related: https://github.com/ansible-community/molecule/pull/3195