### PR TITLE
Add FQCN to podman modules

### DIFF
--- a/lib/molecule_podman/playbooks/create.yml
+++ b/lib/molecule_podman/playbooks/create.yml
@@ -52,7 +52,7 @@
       register: platforms
 
     - name: Discover local Podman images
-      podman_image_info:
+      containers.podman.podman_image_info:
         name: "molecule_local/{{ item.item.name }}"
       with_items: "{{ platforms.results }}"
       loop_control:

--- a/lib/molecule_podman/playbooks/validate-dockerfile.yml
+++ b/lib/molecule_podman/playbooks/validate-dockerfile.yml
@@ -37,7 +37,7 @@
         label: "{{ item.image }}"
 
     - name: Build Dockerfile(s)
-      podman_image:
+      containers.podman.podman_image:
         name: "{{ item.item.image }}"
         path: "{{ temp_image_dirs.results[index].path }}"
         state: build


### PR DESCRIPTION
Some of modules have been used without FQCN, add containers.podman
namespace to them.