### PR TITLE
Require containers.podman>=1.6.2

### DIFF
--- a/lib/molecule_podman/driver.py
+++ b/lib/molecule_podman/driver.py
@@ -194,4 +194,4 @@ class Podman(Driver):
     @property
     def required_collections(self) -> Dict[str, str]:
         """Return collections dict containing names and versions required."""
-        return {"containers.podman": "1.6.1"}
+        return {"containers.podman": "1.6.2"}

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,9 @@ setenv =
     ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
     ANSIBLE_DISPLAY_FAILED_STDERR=1
     ANSIBLE_VERBOSITY=1
+    # enabling pipelineing as it was known to break podman module in order
+    # versions, added here as a safety measure to prevent regression.
+    ANSIBLE_PIPELINING=1
     PYTHONDONTWRITEBYTECODE=1
     PYTHONUNBUFFERED=1
     # new resolve a must or test extras will not install right
@@ -45,7 +48,7 @@ deps =
 commands =
     ansibledevel: ansible-galaxy collection install git+https://github.com/containers/ansible-podman-collections
     # this should mention oldest version we find acceptable for runtime
-    ansible-galaxy collection install 'containers.podman:==1.6.1'
+    ansible-galaxy collection install 'containers.podman:==1.6.2'
     # failsafe as pip may install incompatible dependencies
     pip check
     # failsafe for preventing changes that may break pytest collection


### PR DESCRIPTION
This should fix previous bug where enabling pipelining broke the molecule-podman driver.

Related: https://github.com/containers/ansible-podman-collections/pull/275
Fixes: #2 