### PR TITLE
Allow podman executable override with env

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,9 @@ variable ``MOLECULE_PODMAN_EXECUTABLE``. For instance, if you wish to run
 molecule with ``podman-remote`` instead of ordinary ``podman``, the variable
 can be exported as:
 
-export MOLECULE_PODMAN_EXECUTABLE=podman-remote
+.. code-block:: console
+
+   $ export MOLECULE_PODMAN_EXECUTABLE=podman-remote
 
 .. _get-involved:
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,10 @@ Please note that this driver is currently in its early stage of development.
 Change podman executable
 ========================
 
-To change the podman executable from the standard podman, export environment variable MOLECULE_PODMAN_EXECUTABLE. For instance if you wish to run molecule with podman-remote instead of ordinary podman, the variable can be exportet as:
+To change the podman executable from the standard podman, export environment
+variable ``MOLECULE_PODMAN_EXECUTABLE``. For instance, if you wish to run
+molecule with ``podman-remote`` instead of ordinary ``podman``, the variable
+can be exported as:
 
 export MOLECULE_PODMAN_EXECUTABLE=podman-remote
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,8 @@ This plugin requires `containers.podman` collection to be present:
 
 Please note that this driver is currently in its early stage of development.
 
-**Change podman executable**
+Change podman executable
+========================
 
 To change the podman executable from the standard podman, export environment variable MOLECULE_PODMAN_EXECUTABLE. For instance if you wish to run molecule with podman-remote instead of ordinary podman, the variable can be exportet as:
 

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,7 @@ This plugin requires `containers.podman` collection to be present:
 
 Please note that this driver is currently in its early stage of development.
 
-Change podman executable
-------------------------
+**Change podman executable**
 
 To change the podman executable from the standard podman, export environment variable MOLECULE_PODMAN_EXECUTABLE. For instance if you wish to run molecule with podman-remote instead of ordinary podman, the variable can be exportet as:
 

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,13 @@ This plugin requires `containers.podman` collection to be present:
 
 Please note that this driver is currently in its early stage of development.
 
+Change podman executable
+------------------------
+
+To change the podman executable from the standard podman, export environment variable MOLECULE_PODMAN_EXECUTABLE. For instance if you wish to run molecule with podman-remote instead of ordinary podman, the variable can be exportet as:
+
+export MOLECULE_PODMAN_EXECUTABLE=podman-remote
+
 .. _get-involved:
 
 Get Involved

--- a/src/molecule_podman/driver.py
+++ b/src/molecule_podman/driver.py
@@ -29,7 +29,8 @@ from molecule.api import Driver
 from molecule.util import lru_cache
 
 log = logger.get_logger(__name__)
-# To change the podman executable, set environment variable MOLECULE_PODMAN_EXECUTABLE
+# To change the podman executable, set environment variable
+# MOLECULE_PODMAN_EXECUTABLE
 # An example could be MOLECULE_PODMAN_EXECUTABLE=podman-remote
 podman_exec = os.environ.get("MOLECULE_PODMAN_EXECUTABLE", "podman")
 

--- a/src/molecule_podman/driver.py
+++ b/src/molecule_podman/driver.py
@@ -190,7 +190,7 @@ class Podman(Driver):
     def ansible_connection_options(self, instance_name):
         return {
             "ansible_connection": "podman",
-            "ansible_podman_executable": f"{podman_exec}"
+            "ansible_podman_executable": f"{podman_exec}",
         }
 
     @lru_cache()

--- a/src/molecule_podman/driver.py
+++ b/src/molecule_podman/driver.py
@@ -22,6 +22,8 @@
 from __future__ import absolute_import
 
 import os
+from molecule import util
+import distutils.spawn
 from typing import Dict
 
 from molecule import logger

--- a/src/molecule_podman/driver.py
+++ b/src/molecule_podman/driver.py
@@ -29,6 +29,7 @@ from molecule.api import Driver
 from molecule.util import lru_cache
 
 log = logger.get_logger(__name__)
+podman_exec = os.environ.get("MOLECULE_PODMAN_EXECUTABLE", "podman")
 
 
 class Podman(Driver):
@@ -164,7 +165,7 @@ class Podman(Driver):
     @property
     def login_cmd_template(self):
         return (
-            "podman exec "
+            f"{podman_exec} exec "
             "-e COLUMNS={columns} "
             "-e LINES={lines} "
             "-e TERM=bash "
@@ -184,7 +185,7 @@ class Podman(Driver):
         return {"instance": instance_name}
 
     def ansible_connection_options(self, instance_name):
-        return {"ansible_connection": "podman"}
+        return {"ansible_connection": "podman", "ansible_podman_executable": f"{podman_exec}"}
 
     @lru_cache()
     def sanity_checks(self):

--- a/src/molecule_podman/driver.py
+++ b/src/molecule_podman/driver.py
@@ -21,16 +21,16 @@
 
 from __future__ import absolute_import
 
-import os
-from molecule import util
 import distutils.spawn
+import os
 from typing import Dict
 
-from molecule import logger
+from molecule import logger, util
 from molecule.api import Driver
 from molecule.util import lru_cache
 
 log = logger.get_logger(__name__)
+
 
 class Podman(Driver):
     """

--- a/src/molecule_podman/driver.py
+++ b/src/molecule_podman/driver.py
@@ -188,7 +188,10 @@ class Podman(Driver):
         return {"instance": instance_name}
 
     def ansible_connection_options(self, instance_name):
-        return {"ansible_connection": "podman", "ansible_podman_executable": f"{podman_exec}"}
+        return {
+            "ansible_connection": "podman",
+            "ansible_podman_executable": f"{podman_exec}"
+        }
 
     @lru_cache()
     def sanity_checks(self):

--- a/src/molecule_podman/driver.py
+++ b/src/molecule_podman/driver.py
@@ -29,6 +29,7 @@ from molecule.api import Driver
 from molecule.util import lru_cache
 
 log = logger.get_logger(__name__)
+# To change the podman executable, set environment variable MOLECULE_PODMAN_EXECUTABLE. An example could be MOLECULE_PODMAN_EXECUTABLE=podman-remote
 podman_exec = os.environ.get("MOLECULE_PODMAN_EXECUTABLE", "podman")
 
 

--- a/src/molecule_podman/driver.py
+++ b/src/molecule_podman/driver.py
@@ -152,7 +152,7 @@ class Podman(Driver):
     def __init__(self, config=None):
         """Construct Podman."""
         super(Podman, self).__init__(config)
-        self._name = "podman"        
+        self._name = "podman"
         # To change the podman executable, set environment variable
         # MOLECULE_PODMAN_EXECUTABLE
         # An example could be MOLECULE_PODMAN_EXECUTABLE=podman-remote
@@ -161,7 +161,6 @@ class Podman(Driver):
         if not self.podman_cmd:
             msg = f"command not found in PATH {self.podman_exec}"
             util.sysexit_with_message(msg)
-
 
     @property
     def name(self):

--- a/src/molecule_podman/driver.py
+++ b/src/molecule_podman/driver.py
@@ -29,7 +29,8 @@ from molecule.api import Driver
 from molecule.util import lru_cache
 
 log = logger.get_logger(__name__)
-# To change the podman executable, set environment variable MOLECULE_PODMAN_EXECUTABLE. An example could be MOLECULE_PODMAN_EXECUTABLE=podman-remote
+# To change the podman executable, set environment variable MOLECULE_PODMAN_EXECUTABLE
+# An example could be MOLECULE_PODMAN_EXECUTABLE=podman-remote
 podman_exec = os.environ.get("MOLECULE_PODMAN_EXECUTABLE", "podman")
 
 

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -10,9 +10,12 @@
   tasks:
     - name: get podman executable path
       command: which {{ podman_exec }}
-      register: podman_cmd
+      register: podman_path
       environment:
-        PATH: "{{ ansible_env.PATH}}:/sbin:/usr/sbin"
+        PATH: "{{ ansible_env.PATH}}:/sbin:/usr/sbin" 
+    - name: save path to executable as fact
+      set_fact:
+        podman_cmd: "{{ podman_path.stdout }}"
 
     - name: Log into a container registry
       command: >
@@ -137,7 +140,7 @@
 
     - name: Create molecule instance(s)
       command: >
-        {{ podman_exec }}
+        {{ podman_cmd }}
         {% if item.cgroup_manager is defined %}--cgroup-manager={{ item.cgroup_manager }}{% endif %}
         {% if item.storage_opt is defined %}--storage-opt={{ item.storage_opt }}{% endif %}
         {% if item.storage_driver is defined %}--storage-driver={{ item.storage_driver }}{% endif %}

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -8,9 +8,15 @@
   vars:
     podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
+    - name: get podman executable path
+      command: which {{ podman_exec }}
+      register: podman_cmd
+      environment:
+        PATH: "{{ ansible_env.PATH}}:/sbin:/usr/sbin"
+
     - name: Log into a container registry
       command: >
-        {{ podman_exec }} login
+        {{ podman_cmd }} login
         --username {{ item.registry.credentials.username }}
         --password {{ item.registry.credentials.password }}
         --tls-verify={{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}
@@ -66,7 +72,7 @@
 
     - name: Build an Ansible compatible image  # noqa: no-handler
       command: >
-        {{ podman_exec }} build
+        {{ podman_cmd }} build
         -f {{ item.dest }}
         -t molecule_local/{{ item.item.image }}
         {% if item.item.buildargs is defined %}{% for i,k in item.item.buildargs.items() %}--build-arg={{ i }}={{ k }} {% endfor %}{% endif %}
@@ -99,7 +105,7 @@
     # https://github.com/ansible-community/molecule-podman/issues/22
     - name: Remove possible pre-existing containers
       command: >
-        {{ podman_exec }} rm -f -i -v {% for key in molecule_yml.platforms %}{{ key.name }} {% endfor %}
+        {{ podman_cmd }} rm -f -i -v {% for key in molecule_yml.platforms %}{{ key.name }} {% endfor %}
       register: result
       changed_when: true
       failed_when: false

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -12,7 +12,8 @@
       command: which {{ podman_exec }}
       register: podman_path
       environment:
-        PATH: "{{ ansible_env.PATH}}:/sbin:/usr/sbin" 
+        PATH: "{{ ansible_env.PATH }}:/sbin:/usr/sbin" 
+      changed_when: false 
     - name: save path to executable as fact
       set_fact:
         podman_cmd: "{{ podman_path.stdout }}"

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -12,8 +12,8 @@
       command: which {{ podman_exec }}
       register: podman_path
       environment:
-        PATH: "{{ ansible_env.PATH }}:/sbin:/usr/sbin" 
-      changed_when: false 
+        PATH: "{{ ansible_env.PATH }}:/sbin:/usr/sbin"
+      changed_when: false
     - name: save path to executable as fact
       set_fact:
         podman_cmd: "{{ podman_path.stdout }}"

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -5,10 +5,12 @@
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
   become: "{{ not (item.rootless|default(true)) }}"
+  vars:
+    podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
     - name: Log into a container registry
       command: >
-        podman login
+        {{ podman_exec }} login
         --username {{ item.registry.credentials.username }}
         --password {{ item.registry.credentials.password }}
         --tls-verify={{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}
@@ -54,6 +56,7 @@
     - name: Discover local Podman images
       containers.podman.podman_image_info:
         name: "molecule_local/{{ item.item.name }}"
+        executable: "{{ podman_exec }}"
       with_items: "{{ platforms.results }}"
       loop_control:
         label: "{{ item.item.name | default('None specified') }}"
@@ -63,7 +66,7 @@
 
     - name: Build an Ansible compatible image  # noqa: no-handler
       command: >
-        podman build
+        {{ podman_exec }} build
         -f {{ item.dest }}
         -t molecule_local/{{ item.item.image }}
         {% if item.item.buildargs is defined %}{% for i,k in item.item.buildargs.items() %}--build-arg={{ i }}={{ k }} {% endfor %}{% endif %}
@@ -96,7 +99,7 @@
     # https://github.com/ansible-community/molecule-podman/issues/22
     - name: Remove possible pre-existing containers
       command: >
-        podman rm -f -i -v {% for key in molecule_yml.platforms %}{{ key.name }} {% endfor %}
+        {{ podman_exec }} rm -f -i -v {% for key in molecule_yml.platforms %}{{ key.name }} {% endfor %}
       register: result
       changed_when: true
       failed_when: false
@@ -104,6 +107,7 @@
     - name: Discover local podman networks
       containers.podman.podman_network_info:
         name: "{{ item.network }}"
+        executable: "{{ podman_exec }}"
       loop: "{{ molecule_yml.platforms | flatten(levels=1) }}"
       loop_control:
         extended: true
@@ -117,6 +121,7 @@
     - name: Create podman network dedicated to this scenario
       containers.podman.podman_network:
         name: "{{ podman_network.results[0].ansible_loop.allitems[0].network }}"
+        executable: "{{ podman_exec }}"
         subnet:
           "{{ podman_network.results[0].ansible_loop.allitems[0].subnet }}"
       when:
@@ -126,7 +131,7 @@
 
     - name: Create molecule instance(s)
       command: >
-        podman
+        {{ podman_exec }}
         {% if item.cgroup_manager is defined %}--cgroup-manager={{ item.cgroup_manager }}{% endif %}
         {% if item.storage_opt is defined %}--storage-opt={{ item.storage_opt }}{% endif %}
         {% if item.storage_driver is defined %}--storage-driver={{ item.storage_driver }}{% endif %}

--- a/src/molecule_podman/playbooks/destroy.yml
+++ b/src/molecule_podman/playbooks/destroy.yml
@@ -5,9 +5,11 @@
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
   become: "{{ not (item.rootless|default(true)) }}"
+  vars:
+    podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
     - name: Destroy molecule instance(s)
-      shell: podman container exists {{ item.name }} && podman rm -f {{ item.name }} || true
+      shell: "{{ podman_exec }} container exists {{ item.name }} && {{ podman_exec }} rm -f {{ item.name }} || true"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200


### PR DESCRIPTION
The idea behind this pull request is to add the posibility of changing the podman executable from the default, podman, to something else through an environment variable, `MOLECULE_PODMAN_EXECUTABLE`. This could for instance be podman-remote instead of podman. In that case the environment variable could be exported as:
```console
$ export MOLECULE_PODMAN_EXECUTABLE=podman-remote
```
The variable has been named `MOLECULE_PODMAN_EXECUTABLE` to match the similar variable in ansible, namely `ANSIBLE_PODMAN_EXECUTABLE`

Changes have been made both in `driver.py`, `create.yml`, and `destroy.yml`, and have been tested with `MOLECULE_PODMAN_EXECUTABLE=podman-remote`

We needed this functionality at my work, and I thought others might be able to use it as well :)