### PR TITLE
Require molecule 3.4.0 or newer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    molecule >= 3.2.0
+    molecule >= 3.4.0
     # selinux python module is needed as least by ansible-podman modules
     # and allows us of isolated (default) virtualenvs. It does not avoid need
     # to install the system selinux libraries but it will provide a clear

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ setenv =
     # new resolve a must or test extras will not install right
     MOLECULE_NO_LOG=0
 deps =
-    py{36,37,38,39}-{!devel}: molecule[ansible,test]>=3.2.0
+    py{36,37,38,39}-{!devel}: molecule[ansible,test]>=3.4.0
     py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@main#egg=molecule[ansible,test]
     dockerfile: ansible>=2.9.12
     selinux


### PR DESCRIPTION
In order to ensure that require_collections would be recognized by molecule we need to be sure we use 3.4.0 at least.