### PR TITLE
Fail fast if ansible 2.9 with pipelining is detected

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,8 @@
 [MESSAGES CONTROL]
 
 disable =
+    # Disabled on purpose
+    wrong-import-order,  # managed by isort
     # TODO(ssbarnea): remove temporary skips adding during initial adoption:
     abstract-method,
     arguments-differ,

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,3 +3,4 @@
 # of ansible and the extra noise would only make it harder to read the
 # testing output.
 deprecation_warnings=False
+pipelining=True

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ setenv =
     # enabling pipelineing as it was known to break podman module in order
     # versions, added here as a safety measure to prevent regression.
     ANSIBLE_PIPELINING=1
+    ansible29: ANSIBLE_PIPELINING=0
     PYTHONDONTWRITEBYTECODE=1
     PYTHONUNBUFFERED=1
     # new resolve a must or test extras will not install right


### PR DESCRIPTION
Prevents use of the driver with known to be broken setup.

Related: #60