### PR TITLE
Raise runtime warning on unsupported configurations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - ansible-compat>=0.5.0
-          - molecule
+          - molecule>=3.5.0a0
           - packaging
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v3.0.0a4
@@ -52,7 +52,7 @@ repos:
       - id: pylint
         additional_dependencies:
           - ansible-core>=2.11.1
-          - molecule
+          - molecule>=3.5.0a0
   - repo: https://github.com/ansible/ansible-lint.git
     rev: v5.1.2
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ setup_requires =
 # These are required in actual runtime:
 install_requires =
     ansible-compat >= 0.5.0
-    molecule >= 3.4.0
+    molecule >= 3.5.0a0
     # selinux python module is needed as least by ansible-podman modules
     # and allows us of isolated (default) virtualenvs. It does not avoid need
     # to install the system selinux libraries but it will provide a clear

--- a/src/molecule_podman/driver.py
+++ b/src/molecule_podman/driver.py
@@ -23,12 +23,13 @@ from __future__ import absolute_import
 
 import distutils.spawn
 import os
+import warnings
 from typing import Dict
 
 from ansible_compat.ports import cache
 from ansible_compat.runtime import Runtime
 from molecule import logger, util
-from molecule.api import Driver
+from molecule.api import Driver, MoleculeRuntimeWarning
 from molecule.constants import RC_SETUP_ERROR
 from molecule.util import sysexit_with_message
 from packaging.version import Version
@@ -216,12 +217,21 @@ class Podman(Driver):
         # TODO(ssbarnea): reuse ansible runtime instance from molecule once it
         # fully adopts ansible-compat
         runtime = Runtime()
-        if runtime.version < Version("2.10.0") and runtime.config.ansible_pipelining:
-            sysexit_with_message(
-                f"Podman connections do not work with Ansible {runtime.version} when pipelining is enabled. "
-                "Disable pipelining or "
-                "upgrade Ansible to 2.11 or newer.",
-                code=RC_SETUP_ERROR,
+        if runtime.version < Version("2.10.0"):
+
+            if runtime.config.ansible_pipelining:
+                sysexit_with_message(
+                    "Podman connections do not work with Ansible "
+                    f"{runtime.version} when pipelining is enabled. "
+                    "Disable pipelining or "
+                    "upgrade Ansible to 2.11 or newer.",
+                    code=RC_SETUP_ERROR,
+                )
+            warnings.warn(
+                f"Use of molecule-podman with Ansible {runtime.version} is "
+                "unsupported, upgrade to Ansible 2.11 or newer. "
+                "Do not raise any bugs if your tests are failing with current configuration.",
+                category=MoleculeRuntimeWarning,
             )
 
     @property


### PR DESCRIPTION
Instead of removing support for Ansible 2.9, do raise a runtime
warning when the unsupported configuration is detected. Molecule
will catch and display these warnings when tests are failing, telling
users to try newer versions.

Related: #70 #60