### PR TITLE
Lazily load podman executable

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,19 +27,19 @@ jobs:
           - tox_env: lint
           # - tox_env: docs
           - tox_env: py36-ansible29
-            PREFIX: PYTEST_REQPASS=4
+            PREFIX: PYTEST_REQPASS=5
           - tox_env: py36-ansible210
-            PREFIX: PYTEST_REQPASS=4
+            PREFIX: PYTEST_REQPASS=5
           - tox_env: py36-ansible211
-            PREFIX: PYTEST_REQPASS=4
+            PREFIX: PYTEST_REQPASS=5
           - tox_env: py37-ansible211
-            PREFIX: PYTEST_REQPASS=4
+            PREFIX: PYTEST_REQPASS=5
           - tox_env: py38-ansible211
-            PREFIX: PYTEST_REQPASS=4
+            PREFIX: PYTEST_REQPASS=5
           - tox_env: py39-ansible211
-            PREFIX: PYTEST_REQPASS=4
+            PREFIX: PYTEST_REQPASS=5
           - tox_env: py39-devel-ansible211
-            PREFIX: PYTEST_REQPASS=4
+            PREFIX: PYTEST_REQPASS=5
           - tox_env: packaging
 
     steps:

--- a/src/molecule_podman/driver.py
+++ b/src/molecule_podman/driver.py
@@ -161,10 +161,17 @@ class Podman(Driver):
         # MOLECULE_PODMAN_EXECUTABLE
         # An example could be MOLECULE_PODMAN_EXECUTABLE=podman-remote
         self.podman_exec = os.environ.get("MOLECULE_PODMAN_EXECUTABLE", "podman")
-        self.podman_cmd = distutils.spawn.find_executable(self.podman_exec)
-        if not self.podman_cmd:
-            msg = f"command not found in PATH {self.podman_exec}"
-            util.sysexit_with_message(msg)
+        self._podman_cmd = None
+
+    @property
+    def podman_cmd(self):
+        """Lazily calculate the podman command."""
+        if not self._podman_cmd:
+            self._podman_cmd = distutils.spawn.find_executable(self.podman_exec)
+            if not self._podman_cmd:
+                msg = f"command not found in PATH {self.podman_exec}"
+                util.sysexit_with_message(msg)
+        return self._podman_cmd
 
     @property
     def name(self):

--- a/src/molecule_podman/test/test_driver.py
+++ b/src/molecule_podman/test/test_driver.py
@@ -1,7 +1,15 @@
 """Unit tests."""
 from molecule import api
 
+from molecule_podman.driver import Podman
+
 
 def test_driver_is_detected():
     """Asserts that molecule recognizes the driver."""
     assert any(str(d) == "podman" for d in api.drivers())
+
+
+def test_driver_initializes_without_podman_executable(monkeypatch):
+    """Make sure we can initiaize driver without having an executable present."""
+    monkeypatch.setenv("MOLECULE_PODMAN_EXECUTABLE", "bad-executable")
+    Podman()


### PR DESCRIPTION
When we introduced the ability to specify podman executable, we inadvertently changed the behavior of the loading mechanism (commit e120aa12fbce7fce2f483f01b24d57de61c67873).

Before that change, it was possible to initialize the podman driver even if the podman executable was not present. In other words, it was OK to install the podman driver without having podman installed on the system.

With the new mechanism in place, Molecule will fail to start when the podman driver is installed and there is no podman executable available on the system.

This commit restores the od lazy-loading behavior.

Fixes #81 