### PR TITLE
Skip podman network creation named with 'bridge'

### DIFF
--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -138,6 +138,7 @@
         - podman_network.results[0].msg is defined
         - "'no such network' in podman_network.results[0].msg"
         - podman_network.results[0].networks is undefined
+        - "podman_network.results[0].ansible_loop.allitems[0].network not in ['bridge', 'none', 'host', 'ns', 'private', 'slirp4netns']"
 
     - name: Create molecule instance(s)
       ansible.builtin.command: >


### PR DESCRIPTION
As seen in https://docs.podman.io/en/latest/markdown/podman-run.1.html#network-mode-net , `bridge` is a special name used to create a network stack on the default bridge. 
When a `bridge` podman network is created, it won't be used when  `podman run --network=bridge ...` is executed.
The same happens with `none`, `host`, `ns`, `private`, `slirp4netns`. It won`t be used or it will fail as incomplete argument.