### PR TITLE
Fix missing playbooks in the PyPI wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,10 +84,10 @@ molecule.driver =
 
 [options.package_data]
 * =
-    *.j2
-    *.json
-    *.yaml
-    *.yml
+    **/*.j2
+    **/*.json
+    **/*.yaml
+    **/*.yml
     py.typed
 
 [options.packages.find]


### PR DESCRIPTION
This fixes the error message create action has no playbook that appears
when running molecule test with the molecule-podman driver.

Closes #133 