### PR TITLE
fix: make sure directory for async is correctly set

### DIFF
--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -14,9 +14,15 @@
       environment:
         PATH: "{{ ansible_env.PATH }}:/sbin:/usr/sbin"
       changed_when: false
+
     - name: save path to executable as fact
       ansible.builtin.set_fact:
         podman_cmd: "{{ podman_path.stdout }}"
+
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env','HOME') }}/.ansible_async'"
+      when: (lookup('env','HOME'))
 
     - name: Log into a container registry
       ansible.builtin.command: >

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -21,8 +21,8 @@
 
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:
-        ansible_async_dir: "{{ lookup('env','HOME') }}/.ansible_async'"
-      when: (lookup('env','HOME'))
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: (lookup('env', 'HOME'))
 
     - name: Log into a container registry
       ansible.builtin.command: >

--- a/src/molecule_podman/playbooks/destroy.yml
+++ b/src/molecule_podman/playbooks/destroy.yml
@@ -8,6 +8,11 @@
   vars:
     podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env','HOME') }}/.ansible_async'"
+      when: (lookup('env','HOME'))
+
     - name: Destroy molecule instance(s)
       ansible.builtin.shell: "{{ podman_exec }} container exists {{ item.name }} && {{ podman_exec }} rm -f {{ item.name }} || true"
       register: server

--- a/src/molecule_podman/playbooks/destroy.yml
+++ b/src/molecule_podman/playbooks/destroy.yml
@@ -10,8 +10,8 @@
   tasks:
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:
-        ansible_async_dir: "{{ lookup('env','HOME') }}/.ansible_async'"
-      when: (lookup('env','HOME'))
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: (lookup('env', 'HOME'))
 
     - name: Destroy molecule instance(s)
       ansible.builtin.shell: "{{ podman_exec }} container exists {{ item.name }} && {{ podman_exec }} rm -f {{ item.name }} || true"


### PR DESCRIPTION
In certain cases where the home directory environment variable (`$HOME`) is set and it doesn't match the home directory in `/etc/passwd` the `async_status` task will fail with a message such as:

```
"results_file": "/home/runner/.ansible_async/25596
1675523.4961", "started": 1}, "msg": "could not find job", "results_file": "/root/.ansible_async/255961675523.4961"
```

This fixes that issue by setting the `HOME` environment variable as the `ansible_async_dir` variable that 'async_status' task accepts as a override.

I ran into this issue with the `creator-ee` container that is supposedly going to be fixed but I'm proposing this change as this issue could still occur in other containers/environments.

Related:
https://github.com/ansible/ansible-runner/issues/1024
https://github.com/ansible/creator-ee/issues/19
https://github.com/ansible/ansible-runner/pull/1027
https://github.com/ansible-community/molecule-docker/issues/139
https://github.com/ansible-community/molecule-docker/pull/178