### PR TITLE
fix: simplify podman executable path lookup

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: test
+    - name: Test
       ansible.builtin.debug:
         msg: it worked!

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -13,8 +13,8 @@
         podman_cmd: "{{ lookup('ansible.builtin.first_found', params) }}"
       vars:
         params:
-          files: "{{ [ podman_exec ] }}"
-          paths: "{{ ansible_env.PATH | split(':') + ['/sbin', '/usr/sbin'] }}"
+          files: "{{ [podman_exec] }}"
+          paths: "{{ (lookup('env', 'PATH') | split(':')) + ['/sbin', '/usr/sbin'] }}"
 
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -8,16 +8,13 @@
   vars:
     podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
-    - name: get podman executable path
-      ansible.builtin.command: which {{ podman_exec }}
-      register: podman_path
-      environment:
-        PATH: "{{ ansible_env.PATH }}:/sbin:/usr/sbin"
-      changed_when: false
-
-    - name: save path to executable as fact
+    - name: Register podman executable path
       ansible.builtin.set_fact:
-        podman_cmd: "{{ podman_path.stdout }}"
+        podman_cmd: "{{ lookup('ansible.builtin.first_found', params) }}"
+      vars:
+        params:
+          files: "{{ [ podman_exec ] }}"
+          paths: "{{ ansible_env.PATH | split(':') + ['/sbin', '/usr/sbin'] }}"
 
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -8,13 +8,14 @@
   vars:
     podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
+    - name: Get podman executable path
+      ansible.builtin.command: "command -v {{ podman_exec }}"
+      register: _podman_path
+      changed_when: false
+
     - name: Register podman executable path
       ansible.builtin.set_fact:
-        podman_cmd: "{{ lookup('ansible.builtin.first_found', params) }}"
-      vars:
-        params:
-          files: "{{ [podman_exec] }}"
-          paths: "{{ (lookup('env', 'PATH') | split(':')) + ['/sbin', '/usr/sbin'] }}"
+        podman_cmd: "{{ _podman_path }}"
 
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -15,7 +15,7 @@
 
     - name: Register podman executable path
       ansible.builtin.set_fact:
-        podman_cmd: "{{ _podman_path }}"
+        podman_cmd: "{{ _podman_path.stdout }}"
 
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -9,7 +9,7 @@
     podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
     - name: Get podman executable path
-      ansible.builtin.command: "command -v {{ podman_exec }}"
+      ansible.builtin.shell: "command -v {{ podman_exec }}"
       register: _podman_path
       changed_when: false
 

--- a/src/molecule_podman/playbooks/create.yml
+++ b/src/molecule_podman/playbooks/create.yml
@@ -8,7 +8,7 @@
   vars:
     podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
-    - name: Get podman executable path
+    - name: Get podman executable path  # noqa: command-instead-of-shell
       ansible.builtin.shell: "command -v {{ podman_exec }}"
       register: _podman_path
       changed_when: false
@@ -42,7 +42,7 @@
 
     - name: Check presence of custom Dockerfiles
       ansible.builtin.stat:
-        path: "{{ molecule_scenario_directory + '/' + (item.dockerfile | default( 'Dockerfile.j2')) }}"
+        path: "{{ molecule_scenario_directory + '/' + (item.dockerfile | default('Dockerfile.j2')) }}"
       loop: "{{ molecule_yml.platforms }}"
       loop_control:
         label: "Dockerfile: {{ item.dockerfile | default('None specified') }}"
@@ -52,9 +52,9 @@
       ansible.builtin.template:
         src: >-
           {%- if dockerfile_stats.results[i].stat.exists -%}
-          {{ molecule_scenario_directory + '/' + (item.dockerfile | default( 'Dockerfile.j2')) }}
+           {{ molecule_scenario_directory + '/' + (item.dockerfile | default('Dockerfile.j2')) }}
           {%- else -%}
-          {{ playbook_dir + '/Dockerfile.j2' }}
+           {{ playbook_dir + '/Dockerfile.j2' }}
           {%- endif -%}
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
         mode: "0600"
@@ -83,7 +83,7 @@
         {{ podman_cmd }} build
         -f {{ item.dest }}
         -t molecule_local/{{ item.item.image }}
-        {% if item.item.buildargs is defined %}{% for i,k in item.item.buildargs.items() %}--build-arg={{ i }}={{ k }} {% endfor %}{% endif %}
+        {% if item.item.buildargs is defined %}{% for i, k in item.item.buildargs.items() %}--build-arg={{ i }}={{ k }}{% endfor %}{% endif %}
         {% if item.item.pull is defined %}--pull={{ item.item.pull }}{% endif %}
       with_items: "{{ platforms.results }}"
       loop_control:
@@ -162,18 +162,18 @@
         {% if item.volumes is defined %}{% for i in item.volumes %}--volume {{ i }} {% endfor %}{% endif %}
         {% if item.tmpfs is defined %}{% for i in item.tmpfs %}--tmpfs={{ i }} {% endfor %}{% endif %}
         {% if item.capabilities is defined %}{% for i in item.capabilities %}--cap-add={{ i }} {% endfor %}{% endif %}
-        {% if item.exposed_ports is defined %}--expose="{{ item.exposed_ports|join(',') }}"{% endif %}
+        {% if item.exposed_ports is defined %}--expose="{{ item.exposed_ports | join(',') }}"{% endif %}
         {% if item.published_ports is defined %}{% for i in item.published_ports %}--publish={{ i }} {% endfor %}{% endif %}
         {% if item.ulimits is defined %}{% for i in item.ulimits %}--ulimit={{ i }} {% endfor %}{% endif %}
-        {% if item.dns_servers is defined %}--dns="{{ item.dns_servers|join(',') }}"{% endif %}
-        {% if item.env is defined %}{% for i,k in item.env.items() %}--env={{ i }}={{ k }} {% endfor %}{% endif %}
+        {% if item.dns_servers is defined %}--dns="{{ item.dns_servers | join(',') }}"{% endif %}
+        {% if item.env is defined %}{% for i, k in item.env.items() %}--env={{ i }}={{ k }} {% endfor %}{% endif %}
         {% if item.restart_policy is defined %}--restart={{ item.restart_policy }}{% if item.restart_retries is defined %}:{{ item.restart_retries }}{% endif %}{% endif %}
         {% if item.tty is defined %}--tty={{ item.tty }}{% endif %}
         {% if item.network is defined %}--network={{ item.network }}{% endif %}
         {% if item.ip is defined %}--ip={{ item.ip }}{% endif %}
-        {% if item.etc_hosts is defined %}{% for i,k in item.etc_hosts.items() %}{% if i != item.name %}--add-host {{ i }}:{{ k }} {% endif %}{% endfor %}{% endif %}
+        {% if item.etc_hosts is defined %}{% for i, k in item.etc_hosts.items() %}{% if i != item.name %}--add-host {{ i }}:{{ k }} {% endif %}{% endfor %}{% endif %}
         {% if item.hostname is defined %}--hostname={{ item.hostname }}{% elif item.name is defined %}--hostname={{ item.name }}{% endif %}
-        {% if item.systemd is defined %}--systemd={{ item.systemd|string|lower }}{% endif %}
+        {% if item.systemd is defined %}--systemd={{ item.systemd | string | lower }}{% endif %}
         {{ item.extra_opts | default([]) | join(' ') }}
         {{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}
         {{ (command_directives_dict | default({}))[item.name] | default('') }}

--- a/src/molecule_podman/playbooks/validate-dockerfile.yml
+++ b/src/molecule_podman/playbooks/validate-dockerfile.yml
@@ -1,6 +1,7 @@
 #!/usr/bin/env ansible-playbook
 ---
-- hosts: localhost
+- name: Validate dockerfile
+  hosts: localhost
   connection: local
   gather_facts: false
   collections:


### PR DESCRIPTION
Avoids unnecessary command tasks and removes `which` as a dependency that is not always present in minimal environments. (It's not available in https://github.com/ansible/creator-ee for example).